### PR TITLE
Fixed setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from setuptools import setup
+from setuptools import setup, find_packages
 from os import chdir
 from os import pardir
 from os.path import abspath
@@ -15,7 +15,7 @@ setup(
     author='Roman Akopov',
     author_email='adontz@gmail.com',
     url='https://github.com/triflesoft/curio-http-server',
-    packages=['curio_http_server'],
+    packages=find_packages(),
     python_requires='>=3.7',
     install_requires=[
         'curio>=0.9',


### PR DESCRIPTION
So that all submodules below the core folder are included in the installation package. Modules like curio_http_server.core were not installed before.

You can check this by creating the package with the sdist command:
`python setup.py sdist`

The resulting tar archive in the `dist` folder misses the whole `core` folder before the fix.